### PR TITLE
Allow selecting which metrics role to use (prometheus or hawkular)

### DIFF
--- a/deployer.sh
+++ b/deployer.sh
@@ -159,7 +159,8 @@ if [ "$INSTALL_MANAGEIQ" == "true" ] && [ "$CONFIGURE_MANAGEIQ_PROVIDER" == "tru
 
   HAWKULAR_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-infra' -o go-template --template='{{.spec.host}}' hawkular-metrics 2> /dev/null)"
   PROMETHEUS_ALERTS_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-metrics' -o go-template --template='{{.spec.host}}' alerts 2> /dev/null)"
-  HTTPD_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-management' -o go-template --template='{{.spec.host}}' httpd 2> /dev/null)"
+  PROMETHEUS_METRICS_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-metrics' -o go-template --template='{{.spec.host}}' metrics 2> /dev/null)"
+  CFME_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-management' -o go-template --template='{{.spec.host}}' httpd 2> /dev/null)"
   CA_CRT="$(${SSH_COMMAND} cat /etc/origin/master/ca.crt)"
   OC_TOKEN="$(${SSH_COMMAND} oc sa get-token -n management-infra management-admin)"
 
@@ -169,13 +170,15 @@ if [ "$INSTALL_MANAGEIQ" == "true" ] && [ "$CONFIGURE_MANAGEIQ_PROVIDER" == "tru
                   --connection=ssh \
                   --ask-pass \
                   --extra-vars \
-                    "provider_name=OCP_with_Prometheus \
-                    mgmt_infra_sa_token=${OC_TOKEN} \
+                    "provider_name=${NAME_PREFIX} \
+                    management_admin_token=${OC_TOKEN} \
                     ca_crt=\"${CA_CRT}\" \
-                    oo_first_master=${MASTER_HOSTNAME} \
-                    httpd_route=${HTTPD_ROUTE} \
+                    ocp_master_host=${MASTER_HOSTNAME} \
+                    cfme_route=${CFME_ROUTE} \
+                    metrics_role=${METRICS_ROLE} \
                     hawkular_route=${HAWKULAR_ROUTE} \
-                    alerts_route=${PROMETHEUS_ALERTS_ROUTE}" \
+                    prometheus_metrics_route=${PROMETHEUS_METRICS_ROUTE} \
+                    prometheus_alerts_route=${PROMETHEUS_ALERTS_ROUTE}" \
                 ${WORKSPACE}/miqplaybook.yml
   if [ $? -ne '0' ]; then
     RETRCODE=1

--- a/inventory_blocks/manageiq.ini
+++ b/inventory_blocks/manageiq.ini
@@ -2,4 +2,4 @@ openshift_management_install_management=true
 openshift_management_app_template=cfme-template
 openshift_management_template_parameters={{'APPLICATION_IMG_NAME': '{manageiq_image}', 'FRONTEND_APPLICATION_IMG_TAG': 'latest'}}
 openshift_management_install_beta=true
-openshift_management_pod_rollout_retries=60
+openshift_management_pod_rollout_retries=90

--- a/miqplaybook.yml
+++ b/miqplaybook.yml
@@ -7,30 +7,30 @@
       name: '{{ provider_name }}'
       type: 'Openshift'
       provider:
-        auth_key: '{{ mgmt_infra_sa_token }}'
-        hostname: '{{ oo_first_master }}'
+        auth_key: '{{ management_admin_token }}'
+        hostname: '{{ ocp_master_host }}'
         port: 8443
         verify_ssl: true
         security_protocol: "ssl-with-validation-custom-ca"
         certificate_authority: '{{ ca_crt }}'
       metrics:
-        auth_key: '{{ mgmt_infra_sa_token }}'
-        role: 'hawkular'
-        hostname: '{{ hawkular_route }}'
+        auth_key: '{{ management_admin_token }}'
+        role: '{{ metrics_role }}'
+        hostname: "{{ hawkular_route if metrics_role == 'hawkular' else prometheus_metrics_route }}"
         port: 443
         verify_ssl: true
         security_protocol: "ssl-with-validation-custom-ca"
         certificate_authority: '{{ ca_crt }}'
       alerts:
-        auth_key: '{{ mgmt_infra_sa_token }}'
+        auth_key: '{{ management_admin_token }}'
         role: 'prometheus_alerts'
-        hostname: '{{ alerts_route }}'
+        hostname: '{{ prometheus_alerts_route }}'
         port: 443
         verify_ssl: true
         security_protocol: "ssl-with-validation-custom-ca"
         certificate_authority: '{{ ca_crt }}'
       manageiq_connection:
-        url: "https://{{ httpd_route }}"
+        url: "https://{{ cfme_route }}"
         username: 'admin'
         password: 'smartvm'
         verify_ssl: false


### PR DESCRIPTION
Setting $METRICS_ROLE in jenkins will allow selecting which metrics role to use when configuring the provider on the Podified ManageIQ installation.