### PR TITLE
Support creating iSCSI LUNs and PVs for Prometheus

### DIFF
--- a/deployer.sh
+++ b/deployer.sh
@@ -196,30 +196,30 @@ else
             ${SSH_COMMAND} oc create -f ${PV_YAML_DIR}/${PV}
           done
     fi
-fi
 
-if [ "$INSTALL_MANAGEIQ" == "true" ] && [ "$CONFIGURE_MANAGEIQ_PROVIDER" == "true" ]; then
-  echo "Checking out Ansible 2.4..."
-  git clone https://github.com/ansible/ansible.git
-  pushd ansible
-  git checkout stable-2.4
-  source hacking/env-setup
-  popd
-  ansible --version
-  echo "Configuring OpenShift provider in ManageIQ..."
+    if [ "$INSTALL_MANAGEIQ" == "true" ] && [ "$CONFIGURE_MANAGEIQ_PROVIDER" == "true" ]; then
+      echo "Checking out Ansible 2.4..."
+      git clone https://github.com/ansible/ansible.git
+      pushd ansible
+      git checkout stable-2.4
+      source hacking/env-setup
+      popd
+      ansible --version
+      echo "Configuring OpenShift provider in ManageIQ..."
 
-  export OPENSHIFT_HAWKULAR_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-infra' -o go-template --template='{{.spec.host}}' hawkular-metrics 2> /dev/null)"
-  export OPENSHIFT_PROMETHEUS_ALERTS_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-metrics' -o go-template --template='{{.spec.host}}' alerts 2> /dev/null)"
-  export OPENSHIFT_PROMETHEUS_METRICS_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-metrics' -o go-template --template='{{.spec.host}}' metrics 2> /dev/null)"
-  export OPENSHIFT_CFME_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-management' -o go-template --template='{{.spec.host}}' httpd 2> /dev/null)"
-  export OPENSHIFT_MASTER_HOST="$(${SSH_COMMAND} oc get nodes -o name |grep master |sed -e 's/nodes\///g')"
-  export OPENSHIFT_CA_CRT="$(${SSH_COMMAND} cat /etc/origin/master/ca.crt)"
-  export OPENSHIFT_MANAGEMENT_ADMIN_TOKEN="$(${SSH_COMMAND} oc sa get-token -n management-infra management-admin)"
+      export OPENSHIFT_HAWKULAR_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-infra' -o go-template --template='{{.spec.host}}' hawkular-metrics 2> /dev/null)"
+      export OPENSHIFT_PROMETHEUS_ALERTS_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-metrics' -o go-template --template='{{.spec.host}}' alerts 2> /dev/null)"
+      export OPENSHIFT_PROMETHEUS_METRICS_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-metrics' -o go-template --template='{{.spec.host}}' metrics 2> /dev/null)"
+      export OPENSHIFT_CFME_ROUTE="$(${SSH_COMMAND}  oc get route --namespace='openshift-management' -o go-template --template='{{.spec.host}}' httpd 2> /dev/null)"
+      export OPENSHIFT_MASTER_HOST="$(${SSH_COMMAND} oc get nodes -o name |grep master |sed -e 's/nodes\///g')"
+      export OPENSHIFT_CA_CRT="$(${SSH_COMMAND} cat /etc/origin/master/ca.crt)"
+      export OPENSHIFT_MANAGEMENT_ADMIN_TOKEN="$(${SSH_COMMAND} oc sa get-token -n management-infra management-admin)"
 
-  ansible-playbook --extra-vars "provider_name=${NAME_PREFIX} cfme_route=https://${OPENSHIFT_CFME_ROUTE}" ${WORKSPACE}/miqplaybook.yml
-  if [ $? -ne '0' ]; then
-    RETRCODE=1
-  fi
+      ansible-playbook --extra-vars "provider_name=${NAME_PREFIX} cfme_route=https://${OPENSHIFT_CFME_ROUTE}" ${WORKSPACE}/miqplaybook.yml
+      if [ $? -ne '0' ]; then
+        RETRCODE=1
+      fi
+    fi
 fi
 
 COUNTER=1

--- a/deployer.sh
+++ b/deployer.sh
@@ -161,7 +161,7 @@ if [ "${INSTALL_PROMETHEUS}" == "true" ]; then
                                                         --name="cm-${NAME_PREFIX}" \
                                                         --volume="${NETAPP_VOLUME}" \
                                                         --vserver="${NETAPP_VSERVER}" \
-                                                        --size="15GB" \
+                                                        --size="${ISCSI_PV_SIZE}" \
                                                         --initiators="${INITIATORS}")
     set +e
     export ISCSI_LUN_ID

--- a/deployer.sh
+++ b/deployer.sh
@@ -163,6 +163,7 @@ if [ "${INSTALL_PROMETHEUS}" == "true" ]; then
 fi
 
 RETRCODE=0
+SSH_COMMAND="sshpass -p${ROOT_PASSWORD} ssh ${SSH_ARGS} root@${MASTER_HOSTNAME}"
 
 sshpass -p${ROOT_PASSWORD} \
                 ansible-playbook \
@@ -172,8 +173,6 @@ sshpass -p${ROOT_PASSWORD} \
                   --private-key=${ID_FILE} \
                   --inventory=${INVENTORY_PATH} \
                   ${OPENSHIFT_ANSIBLE_PATH}/playbooks/byo/config.yml
-
-SSH_COMMAND="sshpass -p${ROOT_PASSWORD} ssh ${SSH_ARGS} root@${MASTER_HOSTNAME}"
 
 if [ $? -ne '0' ]; then
   RETRCODE=1

--- a/inventory_blocks/prometheus_external_nfs.ini
+++ b/inventory_blocks/prometheus_external_nfs.ini
@@ -1,8 +1,3 @@
-
-openshift_prometheus_storage_kind=nfs
-openshift_prometheus_storage_host={nfs_server}
-openshift_prometheus_storage_nfs_directory={nfs_export_path}
-openshift_prometheus_storage_volume_name=prometheus
 openshift_prometheus_storage_labels={{'storage': 'prometheus'}}
 openshift_prometheus_storage_type=pvc
 

--- a/inventory_blocks/prometheus_internal_nfs.ini
+++ b/inventory_blocks/prometheus_internal_nfs.ini
@@ -1,4 +1,3 @@
-openshift_prometheus_storage_kind=nfs
 openshift_prometheus_storage_labels={{'storage': 'prometheus'}}
 openshift_prometheus_storage_type=pvc
 

--- a/iscsi-pv-template.yaml
+++ b/iscsi-pv-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    storage: prometheus
+  name: promethues-iscsi-pv
+spec:
+  capacity:
+    storage: 15Gi
+  accessModes:
+    - ReadWriteOnce
+  iscsi:
+     targetPortal: ${ISCSI_TARGET_PORTAL}
+     iqn: ${ISCSI_IQN}
+     lun: ${ISCSI_LUN_ID}
+     fsType: 'ext4'
+     readOnly: false
+
+

--- a/lun_manager.py
+++ b/lun_manager.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+# netapp_iscsi_lun_manager.py
+#
+# Copyright © 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals, print_function
+import argparse
+import paramiko
+import sys
+from paramiko import SSHClient
+
+DEFAULT_OVIRT_PASS_ENV_VAR = "OV_PASS"
+
+
+def exec_command(client, command):
+    """ execute a command on an ssh client, return the output streams """
+    stdin, stdout, stderr = client.exec_command(command)
+    out = stdout.read().strip()
+    err = stderr.read().strip()
+    if out:
+        print(out, file=sys.stderr)
+    if err:
+        print(err, file=sys.stderr)
+    return out, err
+
+
+def create_lun(client, volume, vserver, lun_name, size):
+    """ Create a LUN """
+    command = "lun create -vserver {0} -volume {1} -lun {2} -size {3} -ostype linux"
+    command = command.format(vserver, volume, lun_name, size)
+    out, err = exec_command(client, command)
+    if not out.startswith("Created a LUN of size"):
+        raise Exception("Lun creation failed\n" + out + '\n' + err)
+
+
+def create_igroup(client, vserver, igroup_name, initator_list):
+    """ Create an igroup """
+    command = "igroup create -vserver {0} -igroup {1} -protocol iscsi  -ostype linux -initiator {2}"
+    command = command.format(vserver, igroup_name, ", ".join(initator_list))
+    out, err = exec_command(client, command)
+    if out or err:
+        raise Exception("igroup creation failed!")
+
+
+def _mapping(mode, client, vserver, volume, lun_name, igroup_name):
+    if mode not in ["delete", "create"]:
+        raise ValueError(mode)
+
+    command = "mapping {0} -vserver {1} -volume {2} -lun {3} -igroup {4}"
+    command = command.format(mode, vserver, volume, lun_name, igroup_name)
+    out, err = exec_command(client, command)
+    if out != "(lun mapping {0})".format(mode):
+        raise Exception("mapping {0} failed".format(mode))
+
+
+def map_lun(client, vserver, volume, lun_name, igroup_name):
+    """ Map LUN to igroup """
+    _mapping("create", client, vserver, volume, lun_name, igroup_name)
+
+    # Find the lun ID (useful for the PV file)
+    out, err = exec_command(client, "mapping show")
+    for line in out.splitlines():
+        splitted = line.split()
+        if splitted[2] == lun_name:
+            print(splitted[3])
+            return
+
+    raise Exception("Could not find LUN ID number")
+
+
+def delete_lun_mapping(client, vserver, volume, lun_name, igroup_name):
+    """ Delete LUN mapping """
+    _mapping("delete", client, vserver, volume, lun_name, igroup_name)
+
+
+def delete_lun(client, volume, vserver, lun_name):
+    """ Delete a LUN """
+    command = "lun delete -vserver {0} -volume {1} -lun {2} -force"
+    command = command.format(vserver, volume, lun_name)
+    out, err = exec_command(client, command)
+    if out or err:
+        raise Exception("Lun deletion failed\n" + out + '\n' + err)
+
+
+def delete_igroup(client, vserver, igroup_name):
+    """ Delete an igroup """
+    command = "igroup delete -vserver {0} -igroup {1}"
+    command = command.format(vserver, igroup_name)
+    out, err = exec_command(client, command)
+    if out or err:
+        raise Exception("igroup deletion failed!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Manage LUNs, mappings and igroups on a NetApp cluster')
+
+    # netapp parameters
+    parser.add_argument('--server', nargs='?', type=str, help="NetApp server address", required=True)
+    parser.add_argument('--username', nargs='?', type=str, help="Username for the NetApp cluster", required=True)
+    parser.add_argument('--action', nargs='?', choices=["create", "delete", "clean"], default="create")
+    parser.add_argument('--name', nargs='?', type=str, help="LUN name")
+    parser.add_argument('--volume', nargs='?', type=str)
+    parser.add_argument('--vserver', nargs='?', type=str, help="vserver for the LUN")
+    parser.add_argument('--size', nargs='?', type=str, help="LUN Size")
+    parser.add_argument('--initiators', nargs='?', type=str, help="List of initiators for the lun igroup")
+
+    # ovirt parameters, only required for "cleanup" mode
+    parser.add_argument('--ovirt-url', type=str,
+                        help='The url pointing to the oVirt Engine API end point')
+    parser.add_argument('--ovirt-user', type=str,
+                        help='The user to use to authenticate with the oVirt Engine')
+    parser.add_argument('--ovirt-ca-pem-file', type=str,
+                        help='Path to the ca pem file to use when connecting to tyhe engine')
+    parser.add_argument('--ovirt-pass', const=DEFAULT_OVIRT_PASS_ENV_VAR, nargs='?',
+                        type=str, default=DEFAULT_OVIRT_PASS_ENV_VAR,
+                        help='Env variables to use to get the password to authenticate to oVirt')
+
+    args = parser.parse_args()
+    if args.action == "create":
+        if not args.name or not args.volume or not args.vserver or not args.size or not args.initiators:
+            raise SystemExit("name, volume, vserver, size and initators are required for create")
+    elif args.action == "delete":
+        if not args.name or not args.volume or not args.vserver:
+            raise SystemExit("name, volume and vserver are required for delete")
+    elif args.action == "cleanup":
+        if not args.ovirt_url or not args.ovirt_user or not args.ovirt_ca_pem_file:
+            raise SystemExit("missing ovirt arguments")
+
+    client = SSHClient()
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.WarningPolicy())
+
+    try:
+        client.connect(args.server, username=args.username)
+        exec_command(client, "rows 0")  # For easier output parsing
+
+        if args.action == "create":
+            # Creating a new LUN
+            create_lun(client, args.volume, args.vserver, args.name, args.size)
+            create_igroup(client, args.vserver, args.name, args.initiators.split())
+            map_lun(client, args.vserver, args.volume, args.name, args.name)
+        elif args.action == "delete":
+            # Deleting a LUN
+            delete_lun_mapping(client, args.vserver, args.volume, args.name, args.name)
+            delete_igroup(client, args.vserver, args.name)
+            delete_lun(client, args.volume, args.vserver, args.name)
+        elif args.action == "cleanup":
+            raise NotImplementedError("Automatic cleanup not yet implemented")
+
+        print("Done!", file=sys.stderr)
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
```
usage: lun_manager.py [-h] --server [SERVER] --username [USERNAME]
                      [--action [{create,delete,clean}]] [--name [NAME]]
                      [--volume [VOLUME]] [--vserver [VSERVER]]
                      [--size [SIZE]] [--initiators [INITIATORS]]
                      [--ovirt-url OVIRT_URL] [--ovirt-user OVIRT_USER]
                      [--ovirt-ca-pem-file OVIRT_CA_PEM_FILE]
                      [--ovirt-pass [OVIRT_PASS]]
```

lun_manager can create / delete luns, mappings and igroups on a netapp cluster. It has some groundwork for a "cleanup mode" in which it'll query oVirt to see which clusters are gone, and will delete their luns if needed, but that's not implemented yet.

It also outputs the "lun number" / "lun ID" so we can use that in the pv definition to make sure we're using the correct lun.

On the `deployer.sh` side, we set the iscsi initiator names to match the node names so we can easily see which nodes can access which luns, and we create the iscsi pv for prometheus manually (since openshift_ansible doesn't seem to support that).

Note that we create the PV after the deployment is done, but that's not a problem because openshift_ansible does not wait for prometheus to start before it moves on to do other things. Once the PV is created and the pvc claim from prometheus is fulfilled it will start up automatically.