### PR TITLE
Assign alert profile to the enterprise when deploying ManageIQ

### DIFF
--- a/miq_scripts/run.rb
+++ b/miq_scripts/run.rb
@@ -1,0 +1,4 @@
+print "Assinging alert profiles to the Enterprise\n"
+
+MiqAlertSet.find_by(:guid=>"a16fcf51-e2ae-492d-af37-19de881476ad").assign_to_objects(MiqEnterprise.last)
+MiqAlertSet.find_by(:guid=>"ff0fb114-be03-4685-bebb-b6ae8f13d7ad").assign_to_objects(MiqEnterprise.last)

--- a/miq_scripts/run.sh
+++ b/miq_scripts/run.sh
@@ -1,0 +1,2 @@
+source /etc/default/evm
+rails r miq_scripts/run.rb


### PR DESCRIPTION
This still uses the hack from my pending PR to manageiq-api.

It will work for now, but a more "proper" solution (until there's actual API for this) would be to use `oc rsh` to run some ruby code to make that assignment.

cc @bazulay 