### PR TITLE
Enable C&U roles when deploying ManageIQ

### DIFF
--- a/miq_scripts/run.rb
+++ b/miq_scripts/run.rb
@@ -7,7 +7,7 @@ puts "Enabling C&U roles"
 
 server_config = MiqServer.my_server.get_config()
 roles = server_config.config[:server][:role].split(',')
-roles |= ['ems_metrics_collector','ems_metrics_coordinator','ems_metrics_processor']
+roles |= ['cockpit_ws', 'smartproxy', 'smartstate', 'ems_metrics_collector','ems_metrics_coordinator','ems_metrics_processor']
 roles = roles.sort().join(',')
 MiqServer.my_server.set_config(:server=>{:role => roles})
 MiqServer.my_server.save()

--- a/miq_scripts/run.rb
+++ b/miq_scripts/run.rb
@@ -7,7 +7,7 @@ puts "Enabling C&U roles"
 
 server_config = MiqServer.my_server.get_config()
 roles = server_config.config[:server][:role].split(',')
-roles += ['ems_metrics_collector','ems_metrics_coordinator','ems_metrics_processor']
+roles |= ['ems_metrics_collector','ems_metrics_coordinator','ems_metrics_processor']
 roles = roles.sort().join(',')
 MiqServer.my_server.set_config(:server=>{:role => roles})
 MiqServer.my_server.save()

--- a/miq_scripts/run.rb
+++ b/miq_scripts/run.rb
@@ -1,4 +1,13 @@
-print "Assinging alert profiles to the Enterprise\n"
+puts "Assinging alert profiles to the Enterprise"
 
 MiqAlertSet.find_by(:guid=>"a16fcf51-e2ae-492d-af37-19de881476ad").assign_to_objects(MiqEnterprise.last)
 MiqAlertSet.find_by(:guid=>"ff0fb114-be03-4685-bebb-b6ae8f13d7ad").assign_to_objects(MiqEnterprise.last)
+
+puts "Enabling C&U roles"
+
+server_config = MiqServer.my_server.get_config()
+roles = server_config.config[:server][:role].split(',')
+roles += ['ems_metrics_collector','ems_metrics_coordinator','ems_metrics_processor']
+roles = roles.sort().join(',')
+MiqServer.my_server.set_config(:server=>{:role => roles})
+MiqServer.my_server.save()


### PR DESCRIPTION
(Note that this method for automatically enabling C&U roles works when running Podified ManageIQ without requiring a restart, but does require a restart if you try to use it on a local installation when running with `rails s`).

@bazulay @moolitayer @cben please review.