### PR TITLE
Attempt to create the Prometheus iscsi pv even if ansible failed

### DIFF
--- a/deployer.sh
+++ b/deployer.sh
@@ -181,15 +181,18 @@ sshpass -p${ROOT_PASSWORD} \
 
 if [ $? -ne '0' ]; then
   RETRCODE=1
-else
-    if [ "${INSTALL_PROMETHEUS}" == "true" ]; then
-        echo "Creating iSCSI pv (for Prometheus)..."
-        export ISCSI_TARGET_PORTAL
-        export ISCSI_IQN
-        envsubst < "${WORKSPACE}/iscsi-pv-template.yaml" > iscsi_pv.yaml
-        sshpass -p${ROOT_PASSWORD} rsync -e "ssh ${SSH_ARGS}" -Pahvz iscsi_pv.yaml root@${MASTER_HOSTNAME}:
-        ${SSH_COMMAND} oc create -f iscsi_pv.yaml
-    fi
+fi
+
+if [ "${INSTALL_PROMETHEUS}" == "true" ]; then
+    echo "Creating iSCSI pv (for Prometheus)..."
+    export ISCSI_TARGET_PORTAL
+    export ISCSI_IQN
+    envsubst < "${WORKSPACE}/iscsi-pv-template.yaml" > iscsi_pv.yaml
+    sshpass -p${ROOT_PASSWORD} rsync -e "ssh ${SSH_ARGS}" -Pahvz iscsi_pv.yaml root@${MASTER_HOSTNAME}:
+    ${SSH_COMMAND} oc create -f iscsi_pv.yaml
+fi
+
+if [ "$RETRCODE" == "0" ]; then
     if [ "${STORAGE_TYPE}" == "external_nfs" ]; then
           echo "Creating PVs..."
           sshpass -p${ROOT_PASSWORD} rsync -e "ssh ${SSH_ARGS}" -Pahvz ${TMP_RESOURCE_DIR} root@${MASTER_HOSTNAME}:


### PR DESCRIPTION
Sometimes the installation failed because ManageIQ didn't
want to come up, but the rest of the cluster is pretty usable,
so it makes sense to try creating the pv regardless of ansible's
return code (so later on you could re-run only the failed roles and get a fully working cluster).

@oourfali this should fix one of the problems you were having.

Perhaps this is a sign we should modify the Prometheus role to create the PV instead of doing it manually like we do now. @zgalor what do you think?