### PR TITLE
Remove example block of registry.hacker.com

### DIFF
--- a/inventory-template.ini
+++ b/inventory-template.ini
@@ -15,7 +15,6 @@ deployment_type=openshift-enterprise
 
 openshift_docker_additional_registries={additional_registries}
 openshift_docker_insecure_registries={additional_registries}
-openshift_docker_blocked_registries=registry.hacker.com
 
 openshift_disable_check=disk_availability,docker_storage,memory_availability,docker_image_availability
 


### PR DESCRIPTION
These create:
```
BLOCK_REGISTRY='--block-registry registry.hacker.com'
```
line in /etc/sysconfig/docker on the machines.  I suppose we copy-pasted this from some example...

Not sure if worth merging because it's harmless, and maybe will break something...